### PR TITLE
1.21.9 & 1.21.10 Crash Fix

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,16 +4,16 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-loom_version=1.9-SNAPSHOT
+loom_version=1.13-SNAPSHOT
 java_version=21
-minecraft_version=1.21.4
-yarn_mappings=1.21.4+build.2
-loader_version=0.16.9
+minecraft_version=1.21.10
+yarn_mappings=1.21.10+build.2
+loader_version=0.18.1
 
 # Fabric API
-fabric_version=0.112.2+1.21.4
+fabric_version=0.138.3+1.21.10
 
 # Mod Properties
-mod_version=1.2.6
+mod_version=1.2.7
 maven_group=eu.gflash
 archives_base_name=quickcraft

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/eu/gflash/quickcraft/client/InputHelper.java
+++ b/src/main/java/eu/gflash/quickcraft/client/InputHelper.java
@@ -1,0 +1,24 @@
+package eu.gflash.quickcraft.client;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.util.InputUtil;
+import net.minecraft.client.util.Window;
+
+import java.util.Arrays;
+
+public abstract class InputHelper {
+    private InputHelper() {}
+
+    public static boolean isKeyPressed(int ...keyCodes){
+        Window window = MinecraftClient.getInstance().getWindow();
+        return Arrays.stream(keyCodes).anyMatch(c -> InputUtil.isKeyPressed(window, c));
+    }
+
+    public static boolean isAltPressed(){
+        return isKeyPressed(InputUtil.GLFW_KEY_LEFT_ALT, InputUtil.GLFW_KEY_RIGHT_ALT);
+    }
+
+    public static boolean isCtrlPressed(){
+        return isKeyPressed(InputUtil.GLFW_KEY_LEFT_CONTROL, InputUtil.GLFW_KEY_RIGHT_CONTROL);
+    }
+}

--- a/src/main/java/eu/gflash/quickcraft/client/InventoryHelper.java
+++ b/src/main/java/eu/gflash/quickcraft/client/InventoryHelper.java
@@ -2,7 +2,6 @@ package eu.gflash.quickcraft.client;
 
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.client.network.ClientPlayerInteractionManager;
 import net.minecraft.entity.player.PlayerInventory;
@@ -12,6 +11,7 @@ import net.minecraft.screen.CraftingScreenHandler;
 import net.minecraft.screen.PlayerScreenHandler;
 import net.minecraft.screen.ScreenHandler;
 import net.minecraft.screen.slot.SlotActionType;
+import net.minecraft.client.util.InputUtil;
 
 public abstract class InventoryHelper {
 	private static boolean craftScheduled = false;
@@ -39,7 +39,8 @@ public abstract class InventoryHelper {
 		if(rsh != null){
 			int resultSlotIndex = rsh.getOutputSlot().getIndex();
 			ItemStack outStack = getResultStack();
-			if(Screen.hasAltDown() || (outStack != null && !hasSpace(inv, outStack))){
+			boolean isAltDown = InputUtil.isKeyPressed(MinecraftClient.getInstance().getWindow(), InputUtil.GLFW_KEY_LEFT_ALT) || InputUtil.isKeyPressed(MinecraftClient.getInstance().getWindow(), InputUtil.GLFW_KEY_RIGHT_ALT) ;
+			if(isAltDown || (outStack != null && !hasSpace(inv, outStack))){
 				ply.dropSelectedItem(true);
 			}
 			im.clickSlot(rsh.syncId, resultSlotIndex, 0, SlotActionType.QUICK_MOVE, ply);

--- a/src/main/java/eu/gflash/quickcraft/client/InventoryHelper.java
+++ b/src/main/java/eu/gflash/quickcraft/client/InventoryHelper.java
@@ -11,10 +11,11 @@ import net.minecraft.screen.CraftingScreenHandler;
 import net.minecraft.screen.PlayerScreenHandler;
 import net.minecraft.screen.ScreenHandler;
 import net.minecraft.screen.slot.SlotActionType;
-import net.minecraft.client.util.InputUtil;
 
 public abstract class InventoryHelper {
 	private static boolean craftScheduled = false;
+
+	private InventoryHelper() {}
 
 	public static void scheduleCraft(){	// craft on the next client tick
 		craftScheduled = true;
@@ -39,8 +40,7 @@ public abstract class InventoryHelper {
 		if(rsh != null){
 			int resultSlotIndex = rsh.getOutputSlot().getIndex();
 			ItemStack outStack = getResultStack();
-			boolean isAltDown = InputUtil.isKeyPressed(MinecraftClient.getInstance().getWindow(), InputUtil.GLFW_KEY_LEFT_ALT) || InputUtil.isKeyPressed(MinecraftClient.getInstance().getWindow(), InputUtil.GLFW_KEY_RIGHT_ALT) ;
-			if(isAltDown || (outStack != null && !hasSpace(inv, outStack))){
+			if(InputHelper.isAltPressed() || (outStack != null && !hasSpace(inv, outStack))){
 				ply.dropSelectedItem(true);
 			}
 			im.clickSlot(rsh.syncId, resultSlotIndex, 0, SlotActionType.QUICK_MOVE, ply);

--- a/src/main/java/eu/gflash/quickcraft/mixin/CraftingScreenHandlerMixin.java
+++ b/src/main/java/eu/gflash/quickcraft/mixin/CraftingScreenHandlerMixin.java
@@ -1,7 +1,8 @@
 package eu.gflash.quickcraft.mixin;
 
 import eu.gflash.quickcraft.client.InventoryHelper;
-import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.util.InputUtil;
 import net.minecraft.inventory.Inventory;
 import net.minecraft.screen.CraftingScreenHandler;
 import org.spongepowered.asm.mixin.Mixin;
@@ -14,7 +15,8 @@ public class CraftingScreenHandlerMixin {
 
 	@Inject(method = "onContentChanged", at = @At("RETURN"))
 	private void onContentChanged(Inventory inventory, CallbackInfo ci){
-		if(Screen.hasControlDown()) {
+		boolean isControlDown = InputUtil.isKeyPressed(MinecraftClient.getInstance().getWindow(), InputUtil.GLFW_KEY_LEFT_CONTROL) || InputUtil.isKeyPressed(MinecraftClient.getInstance().getWindow(), InputUtil.GLFW_KEY_RIGHT_CONTROL) ;
+		if(isControlDown) {
 			InventoryHelper.scheduleCraft();
 		}
 	}

--- a/src/main/java/eu/gflash/quickcraft/mixin/CraftingScreenHandlerMixin.java
+++ b/src/main/java/eu/gflash/quickcraft/mixin/CraftingScreenHandlerMixin.java
@@ -1,8 +1,7 @@
 package eu.gflash.quickcraft.mixin;
 
+import eu.gflash.quickcraft.client.InputHelper;
 import eu.gflash.quickcraft.client.InventoryHelper;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.util.InputUtil;
 import net.minecraft.inventory.Inventory;
 import net.minecraft.screen.CraftingScreenHandler;
 import org.spongepowered.asm.mixin.Mixin;
@@ -15,8 +14,7 @@ public class CraftingScreenHandlerMixin {
 
 	@Inject(method = "onContentChanged", at = @At("RETURN"))
 	private void onContentChanged(Inventory inventory, CallbackInfo ci){
-		boolean isControlDown = InputUtil.isKeyPressed(MinecraftClient.getInstance().getWindow(), InputUtil.GLFW_KEY_LEFT_CONTROL) || InputUtil.isKeyPressed(MinecraftClient.getInstance().getWindow(), InputUtil.GLFW_KEY_RIGHT_CONTROL) ;
-		if(isControlDown) {
+		if(InputHelper.isCtrlPressed()) {
 			InventoryHelper.scheduleCraft();
 		}
 	}

--- a/src/main/java/eu/gflash/quickcraft/mixin/PlayerScreenHandlerMixin.java
+++ b/src/main/java/eu/gflash/quickcraft/mixin/PlayerScreenHandlerMixin.java
@@ -1,8 +1,7 @@
 package eu.gflash.quickcraft.mixin;
 
+import eu.gflash.quickcraft.client.InputHelper;
 import eu.gflash.quickcraft.client.InventoryHelper;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.util.InputUtil;
 import net.minecraft.inventory.Inventory;
 import net.minecraft.screen.PlayerScreenHandler;
 import org.spongepowered.asm.mixin.Mixin;
@@ -15,8 +14,7 @@ public class PlayerScreenHandlerMixin {
 
     @Inject(method = "onContentChanged", at = @At("RETURN"))
     private void onContentChanged(Inventory inventory, CallbackInfo ci){
-        boolean isControlDown = InputUtil.isKeyPressed(MinecraftClient.getInstance().getWindow(), InputUtil.GLFW_KEY_LEFT_CONTROL) || InputUtil.isKeyPressed(MinecraftClient.getInstance().getWindow(), InputUtil.GLFW_KEY_RIGHT_CONTROL) ;
-		if(isControlDown) {
+		if(InputHelper.isCtrlPressed()) {
             InventoryHelper.scheduleCraft();
         }
     }

--- a/src/main/java/eu/gflash/quickcraft/mixin/PlayerScreenHandlerMixin.java
+++ b/src/main/java/eu/gflash/quickcraft/mixin/PlayerScreenHandlerMixin.java
@@ -1,7 +1,8 @@
 package eu.gflash.quickcraft.mixin;
 
 import eu.gflash.quickcraft.client.InventoryHelper;
-import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.util.InputUtil;
 import net.minecraft.inventory.Inventory;
 import net.minecraft.screen.PlayerScreenHandler;
 import org.spongepowered.asm.mixin.Mixin;
@@ -14,7 +15,8 @@ public class PlayerScreenHandlerMixin {
 
     @Inject(method = "onContentChanged", at = @At("RETURN"))
     private void onContentChanged(Inventory inventory, CallbackInfo ci){
-        if(Screen.hasControlDown()) {
+        boolean isControlDown = InputUtil.isKeyPressed(MinecraftClient.getInstance().getWindow(), InputUtil.GLFW_KEY_LEFT_CONTROL) || InputUtil.isKeyPressed(MinecraftClient.getInstance().getWindow(), InputUtil.GLFW_KEY_RIGHT_CONTROL) ;
+		if(isControlDown) {
             InventoryHelper.scheduleCraft();
         }
     }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -30,7 +30,7 @@
   ],
   "depends": {
     "java": ">=${javaVer}",
-    "minecraft": ">=1.21.2",
+    "minecraft": ">=1.21.10",
     "fabricloader": ">=0.11.3",
     "fabric": "*"
   },

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -30,7 +30,7 @@
   ],
   "depends": {
     "java": ">=${javaVer}",
-    "minecraft": ">=1.21.10",
+    "minecraft": ">=1.21.9",
     "fabricloader": ">=0.11.3",
     "fabric": "*"
   },


### PR DESCRIPTION
Resolves #11 

The Crash was occurring due to the Screen.hasCtrlDown and Screen.hasAltDown methods. These don't seem to exist in 1.21.10. 
There is a KeyPressed method in the Screen class, but it needs a KeyInput object, which in turn needs scancodes and GLFW modifiers. 

I opted to use InputUtil.isKeyPressed in its stead. 

Also, updated the fabric, loom and Gradle versions. Bumped the mod to version 1.2.7