### PR TITLE
Upgrade to 26.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 import net.fabricmc.loom.task.ValidateMixinNameTask
 
 plugins {
-    id 'net.fabricmc.fabric-loom-remap' version "${loom_version}"
+    id 'net.fabricmc.fabric-loom' version "${loom_version}"
     id 'maven-publish'
 }
 
@@ -13,9 +13,8 @@ group = project.maven_group
 
 dependencies {
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
-    mappings loom.officialMojangMappings()
-    modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
-    modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+    implementation "net.fabricmc:fabric-loader:${project.loader_version}"
+    implementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_api_version}"
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,6 +16,6 @@ loom_version=1.15.5
 fabric_api_version=0.141.3+26.1
 
 # Mod Properties
-mod_version=1.2.8-mojmap
+mod_version=1.3
 maven_group=eu.gflash
 archives_base_name=quickcraft

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,15 +7,15 @@ org.gradle.configuration-cache=false
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-java_version=21
-minecraft_version=1.21.11
-loader_version=0.18.4
-loom_version=1.15-SNAPSHOT
+java_version=25
+minecraft_version=26.1
+loader_version=0.18.5
+loom_version=1.15.5
 
 # Fabric API
-fabric_version=0.141.3+1.21.11
+fabric_api_version=0.141.3+26.1
 
 # Mod Properties
-mod_version=1.2.7-mojmap
+mod_version=1.2.8-mojmap
 maven_group=eu.gflash
 archives_base_name=quickcraft

--- a/src/main/java/eu/gflash/quickcraft/client/InventoryHelper.java
+++ b/src/main/java/eu/gflash/quickcraft/client/InventoryHelper.java
@@ -7,7 +7,7 @@ import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.AbstractCraftingMenu;
-import net.minecraft.world.inventory.ClickType;
+import net.minecraft.world.inventory.ContainerInput;
 import net.minecraft.world.inventory.CraftingMenu;
 import net.minecraft.world.inventory.InventoryMenu;
 import net.minecraft.world.item.ItemStack;
@@ -43,7 +43,7 @@ public abstract class InventoryHelper {
 			if(InputHelper.isAltPressed() || (outStack != null && !hasSpace(inv, outStack))){
 				ply.drop(true);
 			}
-			im.handleInventoryMouseClick(rsh.containerId, resultSlotIndex, 0, ClickType.QUICK_MOVE, ply);
+			im.handleContainerInput(rsh.containerId, resultSlotIndex, 0, ContainerInput.QUICK_MOVE, ply);
 		}
 	}
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -31,9 +31,9 @@
   ],
   "depends": {
     "java": ">=${javaVer}",
-    "minecraft": ">=1.21.11",
-    "fabricloader": ">=0.11.3",
-    "fabric": "*"
+    "minecraft": ">=26.1",
+    "fabricloader": ">=0.18.5",
+    "fabric-api": "*"
   },
   "custom": {
     "modmenu": {


### PR DESCRIPTION
Made changes to remove loom-remap as it is discontinued in 26.1
Upped all versions required for 26.1

Fixed an enum and method as they have been renamed in 26.1 - this was causing a crash whenever trying to craft in-game.